### PR TITLE
Interactive mode!

### DIFF
--- a/index.js
+++ b/index.js
@@ -62,8 +62,8 @@ function open () {
     console.log('The current package.json doesn\'t contain any coordinates!')
   }
 
-    console.error('To view your current location, type `geopkg preview`')
-    process.exit(1)
+  console.error('To view your current location, type `geopkg preview`')
+  process.exit(1)
 }
 
 function preview () {

--- a/index.js
+++ b/index.js
@@ -20,6 +20,9 @@ switch (cmd) {
   case 'preview':
     preview()
     break
+  case 'interactive':
+    interactive()
+    break
   default:
     _unknown(cmd)
 }
@@ -31,10 +34,11 @@ function help () {
     'Usage: ' + pkg.name + ' [command]\n\n' +
     'If no commands are given, the default "update" command is run\n\n' +
     'Commands:\n' +
-    '  help      Show this help\n' +
-    '  update    Updates the current package.json with current coordinates\n' +
-    '  open      Opens the coordinates found in package.json in the browser\n' +
-    '  preview   Finds your current location and previews it in the browser'
+    '  help         Show this help\n' +
+    '  update       Updates the current package.json with current coordinates\n' +
+    '  open         Opens the coordinates found in package.json in the browser\n' +
+    '  preview      Finds your current location and previews it in the browser\n' +
+    '  interacive   Choose coordinates interactively by dragging a marker on a map\n'
   )
   process.exit()
 }
@@ -64,6 +68,27 @@ function preview () {
     console.log('Opening location in browser...')
     geopkg.openMaps(loc, _done)
   })
+}
+
+function interactive () {
+  var currentCoords = geopkg.getPackageCoords()
+  if (currentCoords) {
+    currentCoords = { lat: currentCoords[0], lng: currentCoords[1] }
+    selectCoordsInteractively(currentCoords)
+  } else {
+    _getLocation(function (err, loc) {
+      if (err) return _done(err)
+      selectCoordsInteractively(loc)
+    })
+  }
+
+  function selectCoordsInteractively(loc) {
+    console.log('Opening location in browser...')
+    geopkg.openMapWithDraggableMarker(loc, function (err, newLoc) {
+      console.log('Updating package.json...')
+      geopkg.updatePkg(newLoc, _done)
+    })
+  }
 }
 
 function _unknown (cmd) {

--- a/index.js
+++ b/index.js
@@ -51,14 +51,19 @@ function update () {
 }
 
 function open () {
-  var currentCoords = geopkg.getPackageCoords()
-  if (currentCoords) {
-    return geopkg.openMaps(currentCoords, _done)
-  } else {
+  var currentPkg = geopkg.getPackage()
+  if (currentPkg && currentPkg.coordinates) {
+    return geopkg.openMaps(currentPkg.coordinates, _done)
+  }
+
+  if (!currentPkg) {
     console.error('Could not find a package.json in the current working directory!')
+  } else {
+    console.log('The current package.json doesn\'t contain any coordinates!')
+  }
+
     console.error('To view your current location, type `geopkg preview`')
     process.exit(1)
-  }
 }
 
 function preview () {

--- a/index.js
+++ b/index.js
@@ -48,20 +48,14 @@ function update () {
 }
 
 function open () {
-  try {
-    var targetPkg = require(path.join(process.cwd(), 'package'))
-  } catch (e) {
+  var currentCoords = geopkg.getPackageCoords()
+  if (currentCoords) {
+    return geopkg.openMaps(currentCoords, _done)
+  } else {
     console.error('Could not find a package.json in the current working directory!')
     console.error('To view your current location, type `geopkg preview`')
     process.exit(1)
-    return
   }
-
-  if (targetPkg.coordinates) return geopkg.openMaps(targetPkg.coordinates, _done)
-
-  console.log('The current package.json doesn\'t contain any coordinates!')
-  console.log('To view your current location, type `geopkg preview`')
-  process.exit(1)
 }
 
 function preview () {

--- a/index.js
+++ b/index.js
@@ -1,7 +1,6 @@
 #!/usr/bin/env node
 'use strict'
 
-var path = require('path')
 var geopkg = require('./lib/geopkg')
 var pkg = require('./package')
 
@@ -82,9 +81,10 @@ function interactive () {
     })
   }
 
-  function selectCoordsInteractively(loc) {
+  function selectCoordsInteractively (loc) {
     console.log('Opening location in browser...')
     geopkg.openMapWithDraggableMarker(loc, function (err, newLoc) {
+      if (err) return _done(err)
       console.log('Updating package.json...')
       geopkg.updatePkg(newLoc, _done)
     })

--- a/lib/geopkg.js
+++ b/lib/geopkg.js
@@ -45,12 +45,10 @@ exports.openMapWithDraggableMarker = function (loc, cb) {
   placeGeoMarker(loc, cb)
 }
 
-exports.getPackageCoords = function () {
+exports.getPackage = function () {
   try {
     var targetPkg = require(path.join(process.cwd(), 'package'))
-    if (targetPkg.coordinates) {
-      return targetPkg.coordinates
-    }
+    return targetPkg
   } catch (e) {
     return null
   }

--- a/lib/geopkg.js
+++ b/lib/geopkg.js
@@ -5,6 +5,7 @@ var util = require('util')
 var path = require('path')
 var fs = require('fs')
 var opn = require('opn')
+var placeGeoMarker = require('place-geo-marker')
 
 exports.locate = require('wifi-triangulate')
 
@@ -38,6 +39,10 @@ exports.updatePkg = function (loc, cb) {
       fs.writeFile(packageFile, data + os.EOL, cb)
     })
   })
+}
+
+exports.openMapWithDraggableMarker = function (loc, cb) {
+  placeGeoMarker(loc, cb)
 }
 
 exports.getPackageCoords = function () {

--- a/lib/geopkg.js
+++ b/lib/geopkg.js
@@ -39,3 +39,14 @@ exports.updatePkg = function (loc, cb) {
     })
   })
 }
+
+exports.getPackageCoords = function () {
+  try {
+    var targetPkg = require(path.join(process.cwd(), 'package'))
+    if (targetPkg.coordinates) {
+      return targetPkg.coordinates
+    }
+  } catch (e) {
+    return null
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "geopkg",
   "version": "2.1.2",
-  "description": "Tag npm moduels with lat/long of where on the planet the module was published",
+  "description": "Tag npm modules with lat/long of where on the planet the module was published.",
   "bin": {
     "geopkg": "index.js"
   },

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
   "preferGlobal": true,
   "dependencies": {
     "opn": "^3.0.2",
+    "place-geo-marker": "0.0.5",
     "wifi-triangulate": "^1.1.1"
   },
   "devDependencies": {


### PR DESCRIPTION
A few commits to integrate noffle/place-geo-marker with geopkg, letting the user use `geopkg interactive` to both place a new marker, or modify the location of an existing marker.

Addresses #1.
